### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.david.tucker.name


### PR DESCRIPTION
This is causing standard links (e.g. dmucker.github.io/www.bayfitted.com) to redirect to the real domains (e.g. www.bayfitted.com) instead of to my custom domain (e.g. www.david.tucker.name/www.bayfitted.com) as described in [the docs](https://help.github.com/articles/custom-domain-redirects-for-github-pages-sites/).
