### PR TITLE
Add a CNAME for david.tucker.name

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+david.tucker.name


### PR DESCRIPTION
The motivation behind the previous revert of this was to better support HTTPS; however, HTTPS is only supported as a base redirect, and full URLs do not work (e.g. http://www.david.tucker.name/keybase.txt) because of the limited configuration options offered by 007names.com. I have more faith in GitHub resolving isaacs/github#156 before 007names changes anything, and, since the site *is* based on GitHub Pages anyways, it makes the sense to wait this out.