### PR TITLE
Remove Google verification and update the sitemap

### DIFF
--- a/google97498a3877539776.html
+++ b/google97498a3877539776.html
@@ -1,1 +1,0 @@
-google-site-verification: google97498a3877539776.html

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
         http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 <url>
-  <loc>http://david.tucker.name/</loc>
+  <loc>https://david.tucker.name/</loc>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>


### PR DESCRIPTION
The Google HTML file method doesn't seem to work with GitHub pages, and there is already a `meta` tag anyways.